### PR TITLE
Changes to remove global variables

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    colorize (0.8.1)
     mini_portile2 (2.4.0)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     nokogiri (1.10.10-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     open-uri (0.1.0)
     uri (0.10.0)
 
 PLATFORMS
+  ruby
   x64-mingw32
 
 DEPENDENCIES
+  colorize
   nokogiri
   open-uri
   uri

--- a/common_methods.rb
+++ b/common_methods.rb
@@ -1,5 +1,4 @@
 require 'colorize'
-require 'pry'
 
 # This looks like the user interface
 class Interface

--- a/common_methods.rb
+++ b/common_methods.rb
@@ -1,27 +1,38 @@
 require 'colorize'
+require 'pry'
 
-def get_search_input
-  puts("")
-  puts("Enter search term(s).".colorize(:green))
-  $search_input = gets.chomp
-end
-
-def get_max_results_input
-  max_results_input_entered = false
-  while defined?($max_results_input).nil? || $max_results_input < 1 || max_results_input_entered == false
+# This looks like the user interface
+class Interface
+  def get_search_input
     puts("")
-    puts("Enter maximum number of results to display. Must be at least 1.".colorize(:green))
-    $max_results_input = gets.chomp.to_i
-    max_results_input_entered = true
-    if $max_results_input < 1
+    puts("Enter search term(s).".colorize(:green))
+    gets.chomp
+  end
+
+  def get_max_results_input
+    max_results_input = nil
+    while(max_results_input.nil? || max_results_input < 1)
       puts("")
-      puts("Invalid input.".colorize(:red))
+      puts("Enter maximum number of results to display. Must be at least 1.".colorize(:green))
+      max_results_input = gets.chomp.to_i
+      if max_results_input < 1
+        puts("")
+        puts("Invalid input.".colorize(:red))
+      end
+    end
+    max_results_input
+  end
+  
+  def display_results(determined_results_to_display, results)
+    puts("")
+    puts("Displaying #{determined_results_to_display} first item(s) in results, ordered by price (ascending):".colorize(:cyan))
+    puts("")
+    results.each do |key, value|
+        puts key
+        puts value[0].to_s + value[1]
+        puts ''
     end
   end
 end
 
-def display_results_listing_text(determined_results_to_display)
-  puts("")
-  puts("Displaying #{determined_results_to_display} first item(s) in results, ordered by price (ascending):".colorize(:cyan))
-  puts("")
-end
+

--- a/coop_methods.rb
+++ b/coop_methods.rb
@@ -1,7 +1,6 @@
 require 'nokogiri'
 require 'open-uri'
 require 'uri'
-require 'pry'
 
 class MakeResults
   # Incase you haven't seen this syntax yet for arguments: 

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,12 +1,11 @@
 require_relative 'common_methods.rb'
 require_relative 'coop_methods.rb'
 
+interface = Interface.new
+
 loop do
-  get_search_input()
-  get_max_results_input()
-  run_coop_search()
-  determine_coop_results_to_display()
-  group_coop_results()
-  sort_coop_results()
-  display_coop_results()
+  query = interface.get_search_input
+  max_results = interface.get_max_results_input
+  results = Search.coop(query, max_results)
+  interface.display_results(max_results, results)
 end


### PR DESCRIPTION
Changes are mainly about structuring and [removing global variables](https://www.google.com/search?q=why+should+not+use+global+variables+ruby&rlz=1C5CHFA_enEE921EE922&oq=why+should+not+use+global+variables+ruby&aqs=chrome..69i57.7076j0j4&sourceid=chrome&ie=UTF-8), didn't look too much into logic.

I have kept all the changes in original files so you can see how I moved your code around.

Also fixed  a warning about deprecation in URI methods using [`URI.encode_www_form`](https://apidock.com/ruby/URI/encode_www_form/class)

Another bit to look is the `while` loop in `get_max_results_input` method 

And lastly have a look at `page.css("div.item-name")[0..max_results-1]` this was to replace the method `determine_coop_results_to_display`

I have not added the sort back in as of yet